### PR TITLE
🔧 Fix issue when passing additional parameters to a driver

### DIFF
--- a/src/Http/BitLyShortener.php
+++ b/src/Http/BitLyShortener.php
@@ -43,7 +43,7 @@ class BitLyShortener extends RemoteShortener
      */
     public function shortenAsync($url, array $options = [])
     {
-        $options = array_merge(Arr::add($this->defaults, 'json.long_url', $url), $options);
+        $options = array_merge_recursive(Arr::add($this->defaults, 'json.long_url', $url), $options);
         $request = new Request('POST', '/v4/shorten');
 
         return $this->client->sendAsync($request, $options)->then(function (ResponseInterface $response) {

--- a/src/Http/FirebaseShortener.php
+++ b/src/Http/FirebaseShortener.php
@@ -51,7 +51,7 @@ class FirebaseShortener extends RemoteShortener
      */
     public function shortenAsync($url, array $options = [])
     {
-        $options = array_merge(Arr::add($this->defaults, 'json.dynamicLinkInfo.link', $url), $options);
+        $options = array_merge_recursive(Arr::add($this->defaults, 'json.dynamicLinkInfo.link', $url), $options);
         $request = new Request('POST', '/v1/shortLinks');
 
         return $this->client->sendAsync($request, $options)->then(function (ResponseInterface $response) {

--- a/src/Http/IsGdShortener.php
+++ b/src/Http/IsGdShortener.php
@@ -38,7 +38,7 @@ class IsGdShortener extends RemoteShortener
      */
     public function shortenAsync($url, array $options = [])
     {
-        $options = Arr::add(array_merge($this->defaults, $options), 'query.url', $url);
+        $options = Arr::add(array_merge_recursive($this->defaults, $options), 'query.url', $url);
         $request = new Request('GET', '/create.php');
 
         return $this->client->sendAsync($request, $options)->then(function (ResponseInterface $response) {

--- a/src/Http/PolrShortener.php
+++ b/src/Http/PolrShortener.php
@@ -49,7 +49,7 @@ class PolrShortener extends RemoteShortener
      */
     public function shortenAsync($url, array $options = [])
     {
-        $options = array_merge(Arr::add($this->defaults, 'query.url', $url), $options);
+        $options = array_merge_recursive(Arr::add($this->defaults, 'query.url', $url), $options);
         $request = new Request('GET', '/api/v2/action/shorten');
 
         return $this->client->sendAsync($request, $options)->then(function (ResponseInterface $response) {

--- a/src/Http/ShorteStShortener.php
+++ b/src/Http/ShorteStShortener.php
@@ -38,7 +38,7 @@ class ShorteStShortener extends RemoteShortener
      */
     public function shortenAsync($url, array $options = [])
     {
-        $options = array_merge($this->defaults, $options);
+        $options = array_merge_recursive($this->defaults, $options);
         $request = new Request('PUT', '/v1/data/url', [], http_build_query(['urlToShorten' => $url]));
 
         return $this->client->sendAsync($request, $options)->then(function (ResponseInterface $response) {


### PR DESCRIPTION
This PR fixes an issue when passing additional parameters via the `$options` parameter of the shorten and shortenAsync functions.

This is only a problem with drivers having arrays in their config defaults, because these arrays will be overwritten completely by the `$options` parameter.